### PR TITLE
fix: change community dynamic link

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ export function getServerSideProps(context) {
 
   if(communityName) return {
     redirect: {
-      destination: `/c/${communityName}+`,
+      destination: Constant.Link.bettersocial,
     }
   }
   

--- a/utils/constant.js
+++ b/utils/constant.js
@@ -35,7 +35,7 @@ const OS = {
 const Link = {
     playstore: 'https://play.google.com/store/apps/details?id=org.bettersocial&utm_campaign=sharedpost&utm_medium=Android',
     appstore: 'https://apps.apple.com/us/app/better-social/id1615684520?utm_campaign=sharedpost&utm_medium=iOS',
-    bettersocial: 'https://bettersocial.org',
+    bettersocial: 'helio.social',
 }
 
 const Constant = {

--- a/utils/dynamicLink.js
+++ b/utils/dynamicLink.js
@@ -129,9 +129,8 @@ const generateCommunityLink = async (communityName) => {
         /**
          * @description Add + to topicId to flag dynamic link
          */
-        // const betterWebAppUrl = `${BETTER_WEB_APP_URL}?communityName=${communityName}+`
-        const betterWebAppUrl = Constant.Link.bettersocial
-        return await generateLongDynamicLink(betterWebAppUrl, Constant.Link.playstore)
+        const betterWebAppUrl = `${BETTER_WEB_APP_URL}?communityName=${communityName}+`
+        return await generateLongDynamicLink(betterWebAppUrl, Constant.Link.playstore, Constant.Link.appstore)
     } catch (e) {
         console.log(e)
         return false


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the redirect mechanism in `getServerSideProps` to use a constant link instead of a community name, enhancing the reliability and consistency of redirects.
- New Feature: Modified the `generateCommunityLink` function to correctly generate dynamic links with the community name parameter, improving the user experience by providing more accurate and relevant links.
- Chore: Updated the `bettersocial` link to `helio.social` in the `Link` object, reflecting our recent rebranding.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->